### PR TITLE
Use 'NoSymm' instead of 'Symm=None' with G09

### DIFF
--- a/autoio-interfaces/elstruct/writer/_gaussian09/templates/all.mako
+++ b/autoio-interfaces/elstruct/writer/_gaussian09/templates/all.mako
@@ -45,7 +45,7 @@ ${gen_lines}
 % if mol_options != '':
 # ${mol_options}
 % endif
-Symmetry=None
+NoSymm
 
 comment: ${comment}
 


### PR DESCRIPTION
The latter prevents point group from being assessed at all, which causes Hessian calculations to fail for atoms.