### PR TITLE
Fix: Remove dummy atoms from opt geometry return

### DIFF
--- a/autoio-interfaces/elstruct/reader/_reader.py
+++ b/autoio-interfaces/elstruct/reader/_reader.py
@@ -209,6 +209,7 @@ def opt_geometry(prog, output_str):
     """
     try:
         geo = _opt_geometry(prog, output_str)
+        geo = automol.geom.without_dummy_atoms(geo)
     except TypeError:
         zma = opt_zmatrix(prog, output_str)
         geo = automol.zmat.geometry(zma)


### PR DESCRIPTION
This was being handled inconsistently before