### PR TITLE
ASE integration

### DIFF
--- a/autoio-interfaces/elstruct/par.py
+++ b/autoio-interfaces/elstruct/par.py
@@ -24,6 +24,9 @@ class Module():
 
 class Program():
     """ Programs supported in elstruct """
+    ASE = 'ase'
+    ASE_PSI4 = 'ase_psi4'
+    ASE_NWX = 'ase_nwx'
     CFOUR2 = 'cfour2'
     GAUSSIAN09 = 'gaussian09'
     GAUSSIAN03 = 'gaussian03'

--- a/autoio-interfaces/elstruct/reader/_ase/__init__.py
+++ b/autoio-interfaces/elstruct/reader/_ase/__init__.py
@@ -1,0 +1,21 @@
+from elstruct.reader._ase.status import has_normal_exit_message, check_convergence_messages
+from ase.units import Hartree
+import ase
+from ase.calculators.psi4 import Psi4
+
+def program_version(out_str):
+    import ast
+    results = ast.literal_eval(out_str)
+    return results['version']
+
+def energy(method, out_str):
+    import ast
+    results = ast.literal_eval(out_str)
+    return results['energy'] / Hartree
+
+__all__ = [
+
+    'has_normal_exit_message',
+    'check_convergence_messages',   
+'program_version'
+]

--- a/autoio-interfaces/elstruct/reader/_ase/__init__.py
+++ b/autoio-interfaces/elstruct/reader/_ase/__init__.py
@@ -1,7 +1,4 @@
 from elstruct.reader._ase.status import has_normal_exit_message, check_convergence_messages
-from ase.units import Hartree
-import ase
-from ase.calculators.psi4 import Psi4
 
 def program_version(out_str):
     import ast
@@ -11,7 +8,7 @@ def program_version(out_str):
 def energy(method, out_str):
     import ast
     results = ast.literal_eval(out_str)
-    return results['energy'] / Hartree
+    return results['energy'] 
 
 __all__ = [
 

--- a/autoio-interfaces/elstruct/reader/_ase/status.py
+++ b/autoio-interfaces/elstruct/reader/_ase/status.py
@@ -1,0 +1,25 @@
+""" status checkers
+"""
+import autoparse.pattern as app
+import autoparse.find as apf
+import elstruct.par
+
+
+# Exit message for the program
+def has_normal_exit_message(output_str):
+    """ does this output string have a normal exit message?
+    """
+    return True
+    # pattern = app.escape('*** ASE exiting successfully.')
+    # return apf.has_match(pattern, output_str, case=False)
+
+def check_convergence_messages(error, success, output_str):
+    """ Assess whether the output file string contains messages
+        denoting all of the requested procedures in the job have converged.
+
+        :param output_str: string of the program's output file
+        :type output_str: str
+        :rtype: bool
+    """
+
+    return True

--- a/autoio-interfaces/elstruct/reader/program_modules.py
+++ b/autoio-interfaces/elstruct/reader/program_modules.py
@@ -22,6 +22,8 @@ def call_module_function(prog, function, *args, **kwargs):
             prog = 'molpro2015'
         elif prog in ('gaussian03'):
             prog = 'gaussian09'
+        elif prog.startswith('ase'):
+            prog = 'ase'
         return prog
 
     new_name = _rename_prog(prog)
@@ -83,6 +85,27 @@ class Job():
 
 # Dictionaries that dictate what writer/reader functionality
 READER_MODULE_DCT = {
+   par.Program.ASE: (
+        Job.ENERGY, Job.GRADIENT,
+        Job.OPT_GEO, Job.OPT_ZMA,
+        Job.EXIT_MSG, Job.ERR_LST, Job.SUCCESS_LST,
+        Job.ERR_MSG, Job.CONV_MSG,
+        Job.PROG_NAME, Job.PROG_VERS
+   ),
+   par.Program.ASE_PSI4: (
+        Job.ENERGY, Job.GRADIENT,
+        Job.OPT_GEO, Job.OPT_ZMA,
+        Job.EXIT_MSG, Job.ERR_LST, Job.SUCCESS_LST,
+        Job.ERR_MSG, Job.CONV_MSG,
+        Job.PROG_NAME, Job.PROG_VERS
+   ),
+    par.Program.ASE_NWX: (
+        Job.ENERGY, Job.GRADIENT,
+        Job.OPT_GEO, Job.OPT_ZMA,
+        Job.EXIT_MSG, Job.ERR_LST, Job.SUCCESS_LST,
+        Job.ERR_MSG, Job.CONV_MSG,
+        Job.PROG_NAME, Job.PROG_VERS
+   ),
     par.Program.CFOUR2: (
         Job.ENERGY, Job.GRADIENT,
         Job.OPT_GEO, Job.OPT_ZMA,

--- a/autoio-interfaces/elstruct/run.py
+++ b/autoio-interfaces/elstruct/run.py
@@ -49,6 +49,7 @@ def direct(input_writer, script_str, run_dir, prog,
             atoms.get_potential_energy()
             version_str = f'ase_{ase.__version__}-psi4_{calc.psi4.__version__}'
             calc.results['version'] = version_str
+            calc.results['energy'] = calc.results['energy'] / Hartree
             input_str = str(calc.parameters)
             output_str = str(calc.results)
     else:

--- a/autoio-interfaces/elstruct/run.py
+++ b/autoio-interfaces/elstruct/run.py
@@ -1,8 +1,11 @@
 """ core run function
 """
 
+from email.mime import audio
 from autorun import from_input_string
-
+import automol
+import ase
+from ase.units import Hartree
 
 def direct(input_writer, script_str, run_dir, prog,
            geo, charge, mult, method, basis, **kwargs):
@@ -29,13 +32,44 @@ def direct(input_writer, script_str, run_dir, prog,
         :returns: the input string, the output string, and the run directory
         :rtype: (str, str)
     """
+    if prog.startswith('ase'):
+        atoms = geom_to_atoms(geo)
+        tokens = prog.split('_')
+        if len(tokens) > 1:
+            calculator = tokens[1]
+        else:
+            pass
+        if calculator == 'psi4':
+            from ase.calculators.psi4 import Psi4
+            calc = Psi4()
+            calc.parameters['basis'] = basis
+            calc.parameters['method'] = method
+            calc.parameters['multiplicity'] = mult
+            atoms.calc = calc
+            atoms.get_potential_energy()
+            version_str = f'ase_{ase.__version__}-psi4_{calc.psi4.__version__}'
+            calc.results['version'] = version_str
+            input_str = str(calc.parameters)
+            output_str = str(calc.results)
+    else:
+        input_str = input_writer(
+            prog=prog,
+            geo=geo, charge=charge, mult=mult, method=method, basis=basis,
+            **kwargs)
 
-    input_str = input_writer(
-        prog=prog,
-        geo=geo, charge=charge, mult=mult, method=method, basis=basis,
-        **kwargs)
-
-    output_strs = from_input_string(script_str, run_dir, input_str)
-    output_str = output_strs[0]
+        output_strs = from_input_string(script_str, run_dir, input_str)
+        output_str = output_strs[0]
 
     return input_str, output_str
+
+
+def geom_to_atoms(geo):
+    from ase import Atoms
+    if automol.zmat.is_valid(geo):
+        geo = automol.zmat.geometry(geo)
+    atoms = Atoms(symbols = automol.geom.symbols(geo), positions = automol.geom.coordinates(geo, angstrom=True) )
+    return atoms
+
+
+def atoms_to_geom(atoms):
+    pass

--- a/autoio-interfaces/elstruct/run.py
+++ b/autoio-interfaces/elstruct/run.py
@@ -1,7 +1,6 @@
 """ core run function
 """
 
-from email.mime import audio
 from autorun import from_input_string
 import automol
 import ase


### PR DESCRIPTION
The goal is add ASE to AutoMech, so that we can make use of other quantum chemistry codes and machine learning potentials. While most available ASE calculators have limitations in terms of input parameters and outputs etc, it is straightforward to define a custom calculator.

The PR is not ready, but at a good place to start the discussion about how to move forward.
@snelliott  and I worked on this during ALCF INCITE Hackathon and bring it to a point where one can run single point energy calculations with the ASE PSI4 calculator.

@avcopan and @sjklipp any suggestions?