### PR TITLE
Read molpro ccsdt-f12 ene, fixed

### DIFF
--- a/elstruct/reader/_molpro2015/energ.py
+++ b/elstruct/reader/_molpro2015/energ.py
@@ -156,7 +156,8 @@ def _ccsd_t_f12_energy(output_str):
         output_str,
         app.one_of_these([
             app.escape('!CCSD(T)-F12b total energy') + app.maybe(':'),
-            app.escape('!RHF-UCCSD(T)-F12b energy'),
+            app.escape('!RHF-UCCSD(T)-F12b energy'), #Open shell, Molpro old
+            app.escape('!RHF-UCCSD(T)-F12 energy') + app.maybe(':'), #Molpro 2024
         ]))
     return ene
 


### PR DESCRIPTION
Made sure it is possible to read open shell energies both for Molpro 2024 and older versions