### PR TITLE
Removed Fossil Variable Call from test_read_rates

### DIFF
--- a/mess_io/tests/test_read_rates.py
+++ b/mess_io/tests/test_read_rates.py
@@ -288,7 +288,7 @@ def test__rxns_labels():
     )
 
     assert ref_rxns1 == mess_io.reader.rates.reactions(
-        KTP_OUT_STR, read_rev=True)
+        KTP_OUT_STR)
 
 
 def test__filter_ktp():


### PR DESCRIPTION
In test_read_rates, function test__rxn_labels, the function reactions() is called, with the following input variables:

KTP_OUT_STR, read_rev=True

The second variable has no read-in into the function reactions() in rates.py, meaning it was likely a fossil. It was documented as such, and removed.