### PR TITLE
Fixed test__species_write.py

### DIFF
--- a/chemkin_io/tests/test__species_write.py
+++ b/chemkin_io/tests/test__species_write.py
@@ -22,8 +22,8 @@ MECH_SPC_DCT = {
 
 SPC_STR = (
     'SPECIES\n\n'
-    'O     ! SMILES: smiles_1         ChI: inchi_1  \n'  # note: dumb spaces
-    'H     ! SMILES: smiles_2         ChI: inchi_2  \n\n'
+    'O     ! SMILES: smiles_1         InChI: inchi_1  \n'  # note: dumb spaces
+    'H     ! SMILES: smiles_2         InChI: inchi_2  \n\n'
     'END\n\n\n'
 )
 


### PR DESCRIPTION
test__species_write.py was missing the IUPAC identifiers in its input lines. This was causing the test to fail, and was fixed by specifying InChI instead of simply ChI.